### PR TITLE
Self contained signup example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+spread-api.min.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,204 @@
+{
+  "name": "spreadapi",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "terser": "^5.3.8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "terser": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "requires": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      }
+    }
+  }
+}

--- a/website/examples/sign-up-form-example.html
+++ b/website/examples/sign-up-form-example.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css"
+    />
+    <script
+      src="https://code.jquery.com/jquery-3.7.1.min.js"
+      integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+      crossorigin="anonymous"
+    ></script>
+    <title>Spreadapi Example Sign-up Form</title>
+  </head>
+  <body>
+    <form id="newsletter-form">
+      <div class="columns is-multiline">
+        <div class="column is-6">
+          <input
+            class="input is-medium is-fullwidth"
+            type="email"
+            id="email"
+            placeholder="Enter your Email"
+          />
+        </div>
+        <div class="column is-6">
+          <button
+            class="button is-medium is-primary is-fullwidth is-clear"
+            id="sign-up"
+          >
+            Sign up
+          </button>
+        </div>
+      </div>
+    </form>
+
+    <!-- A dialog shown after successfully signing-up -->
+    <div id="subscription-success-modal" class="modal">
+      <div class="modal-background"></div>
+      <div class="modal-content">
+        <div class="box is-clearfix">
+          <div>You've been added to the SpreadAPI subscription list!</div>
+          <button
+            class="button is-primary is-pulled-right"
+            id="modal-ok-button"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+      <button class="modal-close is-large" aria-label="close" />
+    </div>
+
+    <script>
+      // This code requires jQuery
+
+      var $form = $("#newsletter-form");
+      var $email = $("#email");
+
+      var $modal = $("#subscription-success-modal");
+      var $signUp = $("#sign-up");
+
+      var $modalOK = $("#modal-ok-button");
+
+      $form.submit(function (e) {
+        e.preventDefault();
+
+        // Don't do anything if email field is empty
+        var email = $email.val();
+        if (!email) {
+          return;
+        }
+
+        // Mark the "signup" button as "loading"
+        $signUp.addClass("is-loading");
+
+        // make the request
+        $.post({
+          // Replace the URL with the one specific for your script
+          url: "https://script.google.com/macros/s/AKfycbzoEi2wm45iNgmtsLf6nzMIo4hxFpZvUKKFTXxJc1jEtN4W9gRo/exec",
+          data: JSON.stringify({
+            method: "POST",
+            sheet: "emails",
+            payload: { email },
+          }),
+        }).then(function () {
+          // Remove the "loading" state from the "signup" button
+          $signUp.removeClass("is-loading");
+
+          // Show the popup saying that user has been added
+          // to the subscription list
+          $modal.addClass("is-active");
+        });
+      });
+
+      // Once user clicks "OK" on the popup saying that he
+      // has been added to the subscription list we want to
+      // close the popup
+      $modalOK.click(function () {
+        $modal.removeClass("is-active");
+      });
+    </script>
+  </body>
+</html>

--- a/website/examples/sign-up-form.md
+++ b/website/examples/sign-up-form.md
@@ -2,101 +2,129 @@
 
 You can create newsletter sign-up in a few minutes with SpreadAPI. In this tutorial we will create a simple sign-up form with only an email field.
 
+This example shows how to create a simple newsletter sign-up form in just a few minutes using SpreadAPI, allowing users to register their email with a single field.
+
 ![The sign-up form that we will create in this tutorial](<../.gitbook/assets/image (20).png>)
 
 First, create a Google Sheet like the one below. It's just a single sheet called _emails_ with a single column _email_.
 
 ![](<../.gitbook/assets/image (18).png>)
 
-Next, follow the [setup instructions](../setup.md) to configure API for your spreadsheet. While configuring authentication add the following line to the script so that everybody can add an entry to your sheet.
+Next, follow the [setup instructions](../setup.md) to configure API for your spreadsheet. While configuring authentication add the following line to the script so that everybody can add an entry to the `emails` sheet.
 
 ```javascript
 User("anonymous", UNSAFE(""), { emails: POST });
 ```
 
-Now you can now create HTML form on your site. The code below is a good starting point. I added a nice confirmation message shown after signing up.
+Now you can now create your site with an HTML form. The code below is a good self-contained starting point, using Bulma CSS and jQuery. I added a nice confirmation message shown after signing up.
 
-```markup
-<!-- I use Bulma CSS framework below. -->
-<!-- Visit https://bulma.io to learn more -->
-
-<!-- The form -->
-<form id="newsletter-form">
-    <div class="columns is-multiline">
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css"
+    />
+    <script
+      src="https://code.jquery.com/jquery-3.7.1.min.js"
+      integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+      crossorigin="anonymous"
+    ></script>
+    <title>Spreadapi Example Sign-up Form</title>
+  </head>
+  <body>
+    <form id="newsletter-form">
+      <div class="columns is-multiline">
         <div class="column is-6">
-            <input class="input is-medium is-fullwidth" type="email" id="email" placeholder="Enter your Email">
+          <input
+            class="input is-medium is-fullwidth"
+            type="email"
+            id="email"
+            placeholder="Enter your Email"
+          />
         </div>
         <div class="column is-6">
-            <button class="button is-medium is-primary is-fullwidth is-clear" id="sign-up">Sign up</button>
+          <button
+            class="button is-medium is-primary is-fullwidth is-clear"
+            id="sign-up"
+          >
+            Sign up
+          </button>
         </div>
-    </div>
-</form>
-
-<!-- A dialog shown after successfully signing-up -->
-<div id="subscription-success-modal" class="modal">
-    <div class="modal-background"></div>
-    <div class="modal-content">
-      <div class="box is-clearfix">
-          <div>
-            You've been added to the SpreadAPI subscription list!
-          </div>
-          <button class="button is-primary is-pulled-right" id="modal-ok-button">OK</button>
       </div>
+    </form>
+
+    <!-- A dialog shown after successfully signing-up -->
+    <div id="subscription-success-modal" class="modal">
+      <div class="modal-background"></div>
+      <div class="modal-content">
+        <div class="box is-clearfix">
+          <div>You've been added to the SpreadAPI subscription list!</div>
+          <button
+            class="button is-primary is-pulled-right"
+            id="modal-ok-button"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+      <button class="modal-close is-large" aria-label="close" />
     </div>
-    <button class="modal-close is-large" aria-label="close"/>
-</div>
+
+    <script>
+      // This code requires jQuery
+
+      var $form = $("#newsletter-form");
+      var $email = $("#email");
+
+      var $modal = $("#subscription-success-modal");
+      var $signUp = $("#sign-up");
+
+      var $modalOK = $("#modal-ok-button");
+
+      $form.submit(function (e) {
+        e.preventDefault();
+
+        // Don't do anything if email field is empty
+        var email = $email.val();
+        if (!email) {
+          return;
+        }
+
+        // Mark the "signup" button as "loading"
+        $signUp.addClass("is-loading");
+
+        // make the request
+        $.post({
+          // Replace the URL with the one specific for your script
+          url: "https://script.google.com/macros/s/AKfycbzoEi2wm45iNgmtsLf6nzMIo4hxFpZvUKKFTXxJc1jEtN4W9gRo/exec",
+          data: JSON.stringify({
+            method: "POST",
+            sheet: "emails",
+            payload: { email },
+          }),
+        }).then(function () {
+          // Remove the "loading" state from the "signup" button
+          $signUp.removeClass("is-loading");
+
+          // Show the popup saying that user has been added
+          // to the subscription list
+          $modal.addClass("is-active");
+        });
+      });
+
+      // Once user clicks "OK" on the popup saying that he
+      // has been added to the subscription list we want to
+      // close the popup
+      $modalOK.click(function () {
+        $modal.removeClass("is-active");
+      });
+    </script>
+  </body>
+</html>
 ```
 
-You are almost done! The only piece missing is the JavaScript sending emails to Google Sheets. You can take advantage of the following snippet at your site:
-
-```javascript
-// This code requires jQuery
-
-var $form = $("#newsletter-form");
-var $email = $("#email");
-
-var $modal = $("#subscription-success-modal");
-var $signUp = $("#sign-up");
-
-var $modalOK = $("#modal-ok-button");
-
-$form.submit(function(e) {
-  e.preventDefault();    
-  
-  // Don't do anything if email field is empty
-  var email = $email.val();
-  if (!email) {
-    return;
-  }
-
-  // Mark the "signup" button as "loading"
-  $signUp.addClass("is-loading");
-  
-  // make the request
-  $.post({
-    // Replace the URL with the one specific for your script
-    url: "https://script.google.com/macros/s/AKfycbzoEi2wm45iNgmtsLf6nzMIo4hxFpZvUKKFTXxJc1jEtN4W9gRo/exec",
-    data: JSON.stringify({
-      method: "POST",
-      sheet: "emails",
-      payload: { email }
-    })
-  }).then(function() {
-    // Remove the "loading" state from the "signup" button 
-    $signUp.removeClass("is-loading");
-    
-    // Show the popup saying that user has been added
-    // to the subscription list  
-    $modal.addClass("is-active");
-  });
-});
-
-// Once user clicks "OK" on the popup saying that he 
-// has been added to the subscription list we want to
-// close the popup
-$modalOK.click(function() {
-  $modal.removeClass("is-active");
-});
-```
-
-That's it. From now your users can sign-up to the newsletter and you will add their emails on Google Sheets!
+That's it. Now your users can sign up to the newsletter and you will add their emails on Google Sheets!


### PR DESCRIPTION
Adds demonstration code for [the sign-up form example](https://spreadapi.roombelt.com/examples/sign-up-form) as a single HTML file; it imports Bulma and jQuery via `<link>` and `<script>` tags, so the HTML works on its own without needing any additional setup. I grabbed the Bulma import from [their starter template](https://bulma.io/documentation/start/overview/#starter-template), the jQuery import comes from the minified version of jQuery Core 3.7.1 on [the jQuery releases page](https://releases.jquery.com/).

~~This isn't ready to be merged yet, there's a few things that need to be done:~~ This is now ready to be merged, as of https://github.com/ziolko/spreadapi/pull/14/commits/6dbe7ada86a9562313739823a3713f453c2a7fd2.
* ~~Integrating this with the written documentation in `website/examples/sign-up-form.md`.~~ Completed.
* ~~The HTML file could probably use some additional explanatory comments.~~ I looked it over, I think it's good to know as it is.
* Deciding if this is the right place in the repo's folder structure to put it. It might be better to put the added HTML file in a separate `examples/` folder at the repo's top level, instead of inside the `website/` folder that contains everything for Gitbook; I'm not sure.
* I added the `.gitignore` and `package-lock.json` files because I was working on this in a Codespace, which automatically runs `npm install` and `npm run build` when starting up for the first time. @ziolko, up to you if you want to keep them in or not.